### PR TITLE
add fix for devise installation timing error with rails admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Installation
 
         piggybak install
 
+(NOTE: If you run into an error saying that piggybak gem is missing, use bundle exec piggybak install)
+
 * Piggybak is now installed and ready to be added to whatever model class will be sold.
 
         class Product < ActiveRecord::Base

--- a/lib/piggybak/cli.rb
+++ b/lib/piggybak/cli.rb
@@ -6,10 +6,14 @@ module Piggybak
   
     desc "install", "install and configure piggybak"
     def install
+      inject_devise
       inject_rails_admin
       run('bundle install')
       run('rake piggybak_engine:install:migrations')
-      run('rake db:migrate')    
+      run('rake db:migrate')   
+      run('rails generate devise:install')
+      run('rails generate devise User') 
+      run('rake db:migrate')      
       run('rails g rails_admin:install')
       run('rake db:migrate')      
       mount_piggybak_route
@@ -17,11 +21,18 @@ module Piggybak
       config_assets_precompile
       welcome
     end
+
+    desc "inject_devise", "add devise"
+    def inject_devise
+      puts 'add reference to devise in GEMFILE'
+      insert_into_file "GEMFILE", "gem 'devise'\n", :after => "source 'https://rubygems.org'\n"
+    end
+
     
     desc "inject_rails_admin", "add rails_admin"
     def inject_rails_admin
       puts 'add reference to rails_admin in GEMFILE'
-      insert_into_file "GEMFILE", "gem 'rails_admin'", :after => "source 'https://rubygems.org'\n"
+      insert_into_file "GEMFILE", "gem 'rails_admin'\n", :after => "gem 'devise'\n"
     end
   
     desc "mount_piggybak_route", "mount piggbak route"


### PR DESCRIPTION
Steph, while working on the variants gem I created a new piggybak store using the installer and ran into some issues which this pull requests addresses:

1) Modified README to indicate that "bundle exec piggybak install" should be used if an error is received saying the piggybak gem is missing

2) Change the install process to install devise and create a user devise model before rails admin install is run.  This solves a chicken and egg problem where rails_admin expects a devise class to exist before it's created.
