### PR TITLE
Fixed typo "GEMFILE" cli.rb

### DIFF
--- a/lib/piggybak/cli.rb
+++ b/lib/piggybak/cli.rb
@@ -36,7 +36,7 @@ module Piggybak
     desc "inject_devise", "add devise"
     def inject_devise
       puts 'add reference to devise in GEMFILE'
-      insert_into_file "GEMFILE", "gem 'devise'\n", :after => "source 'https://rubygems.org'\n"
+      insert_into_file "Gemfile", "gem 'devise'\n", :after => "source 'https://rubygems.org'\n"
     end
 
     


### PR DESCRIPTION
Replaced "GEMFILE" with "Gemfile" in lib/piggybak/cli.rb to be able to run the piggybak install command without erroring out.
