### PR TITLE
Make it possible to pass options to cart_form helper

### DIFF
--- a/app/helpers/piggybak_helper.rb
+++ b/app/helpers/piggybak_helper.rb
@@ -1,9 +1,9 @@
 module PiggybakHelper
-  def cart_form(object)
-    render "piggybak/cart/form", :object => object
+  def cart_form(object, options = {})
+    render "piggybak/cart/form", :object => object, :locals => { :options => options }
   end
   def cart_link
-    cart = Piggybak::Cart.new(request.cookies["cart"]) 
+    cart = Piggybak::Cart.new(request.cookies["cart"])
     nitems = cart.sellables.inject(0) { |nitems, item| nitems + item[:quantity] }
     if nitems > 0 && !["piggybak/orders", "piggybak/cart"].include?(params[:controller])
       link_to "#{pluralize(nitems, 'item')}: #{number_to_currency(cart.total)}", piggybak.cart_url

--- a/app/views/piggybak/cart/_form.html.erb
+++ b/app/views/piggybak/cart/_form.html.erb
@@ -1,7 +1,7 @@
 <% if object.reflections.keys.include?(:piggybak_sellable) -%>
 	<% if object.piggybak_sellable && object.piggybak_sellable.active -%>
 		<% if object.piggybak_sellable.quantity > 0 || object.piggybak_sellable.unlimited_inventory -%>
-			<%= form_tag piggybak.cart_add_url do -%>
+			<%= form_tag piggybak.cart_add_url, locals[:options] do -%>
 			<div id="sellable_details">
 			<span id="title"><%= object.piggybak_sellable.description %></span>
 			<span id="price"><%= number_to_currency object.piggybak_sellable.price %></span>


### PR DESCRIPTION
It allows to customize form behavior (e.g. async processing, styling) without overriding the whole view

I needed such a feature while trying to make the add to cart button not to load the cart page but to let the customer continue shopping, while asynchronously processing the cart. A `data-remote` attribute was the easiest way to handle it IMO.

I think that it can be useful in most cases.
Let me know !

Cheers
