### PR TITLE
Changed how jQuery.on() calls were being bound.

### DIFF
--- a/app/assets/javascripts/piggybak/piggybak.js
+++ b/app/assets/javascripts/piggybak/piggybak.js
@@ -18,12 +18,12 @@ $(function() {
 });
 
 var piggybak = {
-	shipping_els: $('#piggybak_order_shipping_address_attributes_state_id,#piggybak_order_shipping_address_attributes_country_id,#piggybak_order_shipping_address_attributes_zip'),
+	shipping_els: '#piggybak_order_shipping_address_attributes_state_id,#piggybak_order_shipping_address_attributes_country_id,#piggybak_order_shipping_address_attributes_zip',
 	initialize_listeners: function() {
-		piggybak.shipping_els.on('change', function() {
+		$(document).on('change', piggybak.shipping_els, function() {
 			piggybak.update_shipping_options($(this));
 		});
-		$('#piggybak_order_billing_address_attributes_state_id').on('change', function() {
+		$(document).on('change', '#piggybak_order_billing_address_attributes_state_id', function() {
 			piggybak.update_tax();
 		});
 		$('#shipping select').change(function() {


### PR DESCRIPTION
Rebound jQuery.on() handlers to the document so they will behave as jQuery.live() did. See StackOverflow post at http://stackoverflow.com/questions/8065305/whats-the-difference-between-on-and-live-or-bind for a decent explanation of binding with .on().

Note: this commit changes the type of piggybak.shipping_els from a jQuery object to a string as that is what jQuery.on() takes as a param. I noticed this change affects piggybak_coupons (at least until my related pull request gets merged in). It may affect some of the other extensions as well. Not sure if you'd prefer using a separate variable for the string.
