### PR TITLE
Quantity as a number on cart form

### DIFF
--- a/app/views/piggybak/cart/_items.html.erb
+++ b/app/views/piggybak/cart/_items.html.erb
@@ -16,7 +16,7 @@
 		<td><%= number_to_currency item[:sellable].price %></td>
 		<td>
 			<% if page == "cart" -%>
-			<%= text_field_tag "quantity[#{item[:sellable].id}]", item[:quantity] %>
+			<%= number_field_tag "quantity[#{item[:sellable].id}]", item[:quantity] %>
             <% else -%>
 			<%= item[:quantity] %>
 			<% end -%>


### PR DESCRIPTION
Just changed the text_field_tag for the product quantity in the cart for the number_field_tag, so it's easier to change the quantity
