### PR TITLE
Added Piggybak Namespace to all Order.find calls

### DIFF
--- a/app/controllers/piggybak/orders_controller.rb
+++ b/app/controllers/piggybak/orders_controller.rb
@@ -92,7 +92,7 @@ module Piggybak
     end
 
     def email
-      order = Order.find(params[:id])
+      order = Piggybak::Order.find(params[:id])
 
       if can?(:email, order)
         Piggybak::Notifier.order_notification(order).deliver
@@ -104,7 +104,7 @@ module Piggybak
     end
 
     def cancel
-      order = Order.find(params[:id])
+      order = Piggybak::Order.find(params[:id])
 
       if can?(:cancel, order)
         order.recorded_changer = current_user.id


### PR DESCRIPTION
There was an inconsistency with the `find` calls, with some not using the `Piggybak` namespace. This has been fixed.
