### PR TITLE
Fix No route matches missing required keys: [] error

### DIFF
--- a/app/controllers/piggybak/orders_controller.rb
+++ b/app/controllers/piggybak/orders_controller.rb
@@ -70,7 +70,7 @@ module Piggybak
       response.headers['Cache-Control'] = 'no-cache'
 
       if !session.has_key?(:last_order)
-        redirect_to root_url 
+        redirect_to main_app.root_url 
         return
       end
 
@@ -78,7 +78,7 @@ module Piggybak
     end
 
     def list
-      redirect_to root_url if current_user.nil?
+      redirect_to main_app.root_url if current_user.nil?
     end
 
     def download


### PR DESCRIPTION
Without this my application raises exception `ActionController::UrlGenerationError` with message from subject when trying to redirect  to root. I guess it's because of overlap with piggybak's `root` route.

With this change it works fine.

Other issue is that any `*_path` helper which appears in layout must be prefixed with `main_app` in order for it to work on orders or any piggybak pages .
Is there any way around this? 
