### PR TITLE
calculate tax after post processing all line_item types

### DIFF
--- a/app/models/piggybak/order.rb
+++ b/app/models/piggybak/order.rb
@@ -81,6 +81,17 @@ module Piggybak
         end
       end
 
+      # Postprocess everything but payments first
+      self.line_items.each do |line_item|
+        next if line_item.line_item_type == "payment"
+        method = "postprocess_#{line_item.line_item_type}"
+        if line_item.respond_to?(method)
+          if !line_item.send(method)
+            return false
+          end
+        end
+      end
+      
       # Recalculate and create line item for tax
       # If a tax line item already exists, reset price
       # If a tax line item doesn't, create
@@ -95,17 +106,6 @@ module Piggybak
         end
       elsif tax_line_item.any?
         tax_line_item.first.mark_for_destruction
-      end
-
-      # Postprocess everything but payments first
-      self.line_items.each do |line_item|
-        next if line_item.line_item_type == "payment"
-        method = "postprocess_#{line_item.line_item_type}"
-        if line_item.respond_to?(method)
-          if !line_item.send(method)
-            return false
-          end
-        end
       end
      
       # Recalculating total and total due, in case post process changed totals


### PR DESCRIPTION
Moved the tax calculation in `postprocess_order` to after the `postprocess"#{line_item_type}"` so that the tax can be calculated on all items that have the `[:reduce_tax_subtotals]` keys like Coupons.

This fixes the issue in the demo where tax when checking out with coupons would not calculate with the coupon  reduction in tax amount. It was working fine on the front end calculation, just not on `:create`

I originally opened an issue for the PiggybakCoupons extension, but found the issue in the Piggybak::Order model. Fixed solved the problem.