### PR TITLE
Fix engine dependencies

### DIFF
--- a/lib/piggybak.rb
+++ b/lib/piggybak.rb
@@ -7,6 +7,8 @@ require 'active_merchant'
 require 'formatted_changes'
 require 'mask_submissions'
 require 'rack-ssl-enforcer'
+require 'rails_admin'
+require 'devise'
 
 module Piggybak
   def self.config(entity = nil, &block)

--- a/lib/piggybak/cli.rb
+++ b/lib/piggybak/cli.rb
@@ -9,9 +9,6 @@ module Piggybak
       if already_installed?
         update
       else        
-        inject_devise
-        inject_rails_admin
-        run('bundle install')
         run('rake piggybak:install:migrations')
         run('rake db:migrate')   
         run('rails generate devise:install')
@@ -33,19 +30,6 @@ module Piggybak
       say_upgraded
     end
 
-    desc "inject_devise", "add devise"
-    def inject_devise
-      puts 'add reference to devise in GEMFILE'
-      insert_into_file "Gemfile", "gem 'devise'\n", :after => "source 'https://rubygems.org'\n"
-    end
-
-    
-    desc "inject_rails_admin", "add rails_admin"
-    def inject_rails_admin
-      puts 'add reference to rails_admin in GEMFILE'
-      insert_into_file "Gemfile", "gem 'rails_admin'\n", :after => "gem 'devise'\n"
-    end
-  
     desc "mount_piggybak_route", "mount piggybak route"
     def mount_piggybak_route
       insert_into_file "config/routes.rb", "\n  mount Piggybak::Engine => '/checkout', :as => 'piggybak'\n", :after => "Application.routes.draw do\n"

--- a/piggybak.gemspec
+++ b/piggybak.gemspec
@@ -21,4 +21,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'countries', '~> 1.2.2'
   s.add_dependency 'activemerchant'
   s.add_dependency 'rack-ssl-enforcer'
+  s.add_dependency 'devise'
+  s.add_dependency 'rails_admin'
 end


### PR DESCRIPTION
@stephskardal Just checking on the history behind this design, is there a reason to modify the parent app's Gemfile during the Piggybak install process instead of listing Devise and RailsAdmin in the gemspec and loading them via the engine?