### PR TITLE
Use BigDecimal in lieu of Float when dealing with Tax calculation

### DIFF
--- a/app/models/piggybak/tax_calculator/percent.rb
+++ b/app/models/piggybak/tax_calculator/percent.rb
@@ -1,3 +1,5 @@
+require "bigdecimal"
+
 module Piggybak
   class TaxCalculator::Percent
     KEYS = ["state_id", "rate"]
@@ -15,17 +17,18 @@ module Piggybak
     end
 
     def self.rate(method, object)
-      taxable_total = object.subtotal
+      taxable_total = BigDecimal.new object.subtotal
       if object.is_a?(::Piggybak::Order)
         Piggybak.config.line_item_types.each do |k, v|
           if v.has_key?(:reduce_tax_subtotal) && v[:reduce_tax_subtotal]
-            taxable_total += object.send("#{k}_charge")
+            taxable_total += BigDecimal.new object.send("#{k}_charge")
           end
         end
       else
-        taxable_total += object.extra_data[:reduce_tax_subtotal].to_f
+        taxable_total += BidDecimal.new object.extra_data[:reduce_tax_subtotal]
       end
-      method.metadata.detect { |m| m.key == "rate" }.value.to_f * taxable_total
+      decimal_value = BigDecimal.new method.metadata.detect { |m| m.key == "rate" }.value 
+      decimal_value * taxable_total
     end
   end
 end

--- a/app/models/piggybak/tax_method.rb
+++ b/app/models/piggybak/tax_method.rb
@@ -1,3 +1,5 @@
+require "bigdecimal"
+
 module Piggybak
   class TaxMethod < ActiveRecord::Base
     has_many :tax_method_values, :dependent => :destroy
@@ -27,16 +29,16 @@ module Piggybak
     end
 
     def self.calculate_tax(object)
-      total_tax = 0
+      total_tax = BigDecimal.new 0
 
       TaxMethod.all.each do |tax_method|
         calculator = tax_method.klass.constantize
         if calculator.available?(tax_method, object)
-          total_tax += calculator.rate(tax_method, object)
+          total_tax += BigDecimal.new calculator.rate(tax_method, object)
         end 
       end
 
-      ((100*total_tax.to_f).to_i).to_f/(100.to_f)
+      total_tax.truncate 2
     end
 
     def admin_label


### PR DESCRIPTION
This resolved a problem I was having where a tax rate of `0.1*total` was coming out inaccurate for transactions with totals of around $200.